### PR TITLE
[Feature] Enable multiple container and depends on

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "posttest": "yarn lint",
     "prepack": "tsc -b --clean && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "nyc --extension .ts mocha -r ts-node/register --forbid-only \"test/**/*.test.ts\"",
-    "version": "oclif-dev readme && git add README.md"
+    "version": "oclif-dev readme && git add README.md",
+    "postinstall": "tsc"
   },
   "types": "lib/index.d.ts"
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,5 +1,6 @@
 import { flags } from '@oclif/command'
 import { AwsCommand } from '../command'
+import { taskDefinitionfromConfiguration } from '../ecs/task-definition'
 
 export default class Config extends AwsCommand {
   static description = 'Print out current configuration'
@@ -23,9 +24,24 @@ export default class Config extends AwsCommand {
       clusterKey,
       taskName,
     })
+    const { clusterName } = variables
+
+    if (clusterName === undefined || taskName === undefined) {
+      throw new Error('Could not detect $clusterName and $taskName')
+    }
+
+    const taskDefinitionInput = taskDefinitionfromConfiguration({
+      clusterName,
+      taskName,
+      variables,
+      config,
+      envVars,
+    })
+
     this.log('$variables', JSON.stringify(variables, undefined, 2))
     this.log('$envVars', JSON.stringify(envVars, undefined, 2))
     this.log(' ')
     this.log(JSON.stringify(config, undefined, 2))
+    this.log(JSON.stringify(taskDefinitionInput, undefined, 2))
   }
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,6 +1,5 @@
 import { flags } from '@oclif/command'
 import { AwsCommand } from '../command'
-import { taskDefinitionfromConfiguration } from '../ecs/task-definition'
 
 export default class Config extends AwsCommand {
   static description = 'Print out current configuration'
@@ -20,28 +19,13 @@ export default class Config extends AwsCommand {
 
   async run() {
     const { flags: { clusterKey, taskName } } = this.parse(Config)
-    const { config, variables, envVars } = this.configWithVariables({
+    const { variables, envVars } = this.configWithVariables({
       clusterKey,
       taskName,
     })
-    const { clusterName } = variables
-
-    if (clusterName === undefined || taskName === undefined) {
-      throw new Error('Could not detect $clusterName and $taskName')
-    }
-
-    const taskDefinitionInput = taskDefinitionfromConfiguration({
-      clusterName,
-      taskName,
-      variables,
-      config,
-      envVars,
-    })
-
     this.log('$variables', JSON.stringify(variables, undefined, 2))
     this.log('$envVars', JSON.stringify(envVars, undefined, 2))
     this.log(' ')
-    // this.log(JSON.stringify(config, undefined, 2))
-    this.log(JSON.stringify(taskDefinitionInput, undefined, 2))
+    this.log(JSON.stringify(config, undefined, 2))
   }
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -41,7 +41,7 @@ export default class Config extends AwsCommand {
     this.log('$variables', JSON.stringify(variables, undefined, 2))
     this.log('$envVars', JSON.stringify(envVars, undefined, 2))
     this.log(' ')
-    this.log(JSON.stringify(config, undefined, 2))
+    // this.log(JSON.stringify(config, undefined, 2))
     this.log(JSON.stringify(taskDefinitionInput, undefined, 2))
   }
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -37,8 +37,7 @@ export default class Config extends AwsCommand {
       config,
       envVars,
     })
-    const web = config.tasks.web
-    this.log('depends', web.depends_on)
+
     this.log('$variables', JSON.stringify(variables, undefined, 2))
     this.log('$envVars', JSON.stringify(envVars, undefined, 2))
     this.log(' ')

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -37,7 +37,8 @@ export default class Config extends AwsCommand {
       config,
       envVars,
     })
-
+    const web = config.tasks.web
+    this.log('depends', web.depends_on)
     this.log('$variables', JSON.stringify(variables, undefined, 2))
     this.log('$envVars', JSON.stringify(envVars, undefined, 2))
     this.log(' ')

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -41,6 +41,7 @@ export default class RunCommand extends AwsCommand {
       taskName,
       dockerTag,
     })
+
     const { accountId, environment, project, region, clusterName } = variables
     if (clusterName === undefined) {
       throw new Error('Could not detect $clusterName')

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -41,7 +41,6 @@ export default class RunCommand extends AwsCommand {
       taskName,
       dockerTag,
     })
-
     const { accountId, environment, project, region, clusterName } = variables
     if (clusterName === undefined) {
       throw new Error('Could not detect $clusterName')

--- a/src/ecs/task-definition.ts
+++ b/src/ecs/task-definition.ts
@@ -81,7 +81,7 @@ interface Params {
   envVars: KeyValuePairs
 }
 
-export const containerDefinitionFromConfiguration = (params: Params, taskName: string) => {
+const containerDefinitionFromConfiguration = (params: Params, taskName: string) => {
   const { clusterName, variables, config, envVars } = params
   const { region } = variables
   const taskConfig = config.tasks[taskName]
@@ -96,6 +96,7 @@ export const containerDefinitionFromConfiguration = (params: Params, taskName: s
     logConfiguration: logConfigurationFromConfiguration(taskName, variables),
     essential: true,
     readonlyRootFilesystem: false,
+    dependsOn: taskConfig.dependsOn,
   }
 }
 
@@ -104,7 +105,8 @@ export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDef
   const { project, environment } = variables
   const taskConfig = config.tasks[taskName]
 
-  const containerDefinitions = [taskName, ...taskConfig.sibling_containers].map(name => containerDefinitionFromConfiguration(params, name))
+  const taskNames = taskConfig.siblingContainers ? [taskName, ...taskConfig.siblingContainers] : [taskName]
+  const containerDefinitions = taskNames.map(name => containerDefinitionFromConfiguration(params, name))
 
   return {
     family: `${project}-${taskName}-${environment}`,

--- a/src/ecs/task-definition.ts
+++ b/src/ecs/task-definition.ts
@@ -85,6 +85,7 @@ export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDef
   const { clusterName, taskName, variables, config, envVars } = params
   const { project, environment, region } = variables
   const taskConfig = config.tasks[taskName]
+  console.log('taskConfig', taskConfig)
 
   return {
     family: `${project}-${taskName}-${environment}`,

--- a/src/ecs/task-definition.ts
+++ b/src/ecs/task-definition.ts
@@ -81,11 +81,30 @@ interface Params {
   envVars: KeyValuePairs
 }
 
-export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDefinitionCommandInput => {
-  const { clusterName, taskName, variables, config, envVars } = params
-  const { project, environment, region } = variables
+export const containerDefinitionFromConfiguration = (params: Params, taskName: string) => {
+  const { clusterName, variables, config, envVars } = params
+  const { region } = variables
   const taskConfig = config.tasks[taskName]
-  console.log('taskConfig', taskConfig)
+
+  return {
+    name: taskName,
+    image: taskConfig.image,
+    command: taskConfig.command,
+    portMappings: portMappingsFromConfiguration(taskConfig),
+    environment: environmentFromEnvVars(envVars),
+    secrets: secretsFromConfiguration(taskName, clusterName, config, region),
+    logConfiguration: logConfigurationFromConfiguration(taskName, variables),
+    essential: true,
+    readonlyRootFilesystem: false,
+  }
+}
+
+export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDefinitionCommandInput => {
+  const { taskName, variables, config } = params
+  const { project, environment } = variables
+  const taskConfig = config.tasks[taskName]
+
+  const containerDefinitions = [taskName, ...taskConfig.sibling_containers].map(name => containerDefinitionFromConfiguration(params, name))
 
   return {
     family: `${project}-${taskName}-${environment}`,
@@ -97,18 +116,6 @@ export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDef
     ],
     cpu: (taskConfig.cpu || 256).toString(),
     memory: (taskConfig.memory || 512).toString(),
-    containerDefinitions: [
-      {
-        name: taskName,
-        image: taskConfig.image,
-        command: taskConfig.command,
-        portMappings: portMappingsFromConfiguration(taskConfig),
-        environment: environmentFromEnvVars(envVars),
-        secrets: secretsFromConfiguration(taskName, clusterName, config, region),
-        logConfiguration: logConfigurationFromConfiguration(taskName, variables),
-        essential: true,
-        readonlyRootFilesystem: false,
-      },
-    ],
+    containerDefinitions,
   }
 }

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -1,6 +1,7 @@
 export interface ConfigurationTaskDefinition {
   image: string
   command?: string[]
+  depends_on?: KeyValuePairs[]
   envVars?: KeyValuePairs
   cpu: 256 | 512 | 1024 | 2048 | 4096
   memory: 512 | 1024 | 2048 | 3072 | 4096 | 5120 | 6144 | 7168 | 8192 | 12_288 | 16_384
@@ -9,7 +10,7 @@ export interface ConfigurationTaskDefinition {
     keys: string[]
   }>
   ports?: number[]
-  sibling_containers: string[]
+  sibling_containers?: string[]
   taskRoleArn?: string
   executionRoleArn: string
   subnet: 'public' | 'private'

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -1,7 +1,10 @@
 export interface ConfigurationTaskDefinition {
   image: string
   command?: string[]
-  depends_on?: KeyValuePairs[]
+  dependsOn?: Array<{
+    containerName: string
+    condition: string
+  }>
   envVars?: KeyValuePairs
   cpu: 256 | 512 | 1024 | 2048 | 4096
   memory: 512 | 1024 | 2048 | 3072 | 4096 | 5120 | 6144 | 7168 | 8192 | 12_288 | 16_384
@@ -10,7 +13,7 @@ export interface ConfigurationTaskDefinition {
     keys: string[]
   }>
   ports?: number[]
-  sibling_containers?: string[]
+  siblingContainers?: string[]
   taskRoleArn?: string
   executionRoleArn: string
   subnet: 'public' | 'private'

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -9,6 +9,7 @@ export interface ConfigurationTaskDefinition {
     keys: string[]
   }>
   ports?: number[]
+  sibling_containers: string[]
   taskRoleArn?: string
   executionRoleArn: string
   subnet: 'public' | 'private'


### PR DESCRIPTION
### Summary
1. Add `siblingContainers` and `dependsOn` to the task definitions
  - `siblingContainers` allow the user to define multiple containers in one task configuration. 
  
2. Add postinstall options so the package will be automatically compiled after install